### PR TITLE
Save complete set of leaf nodes including pruned nodes

### DIFF
--- a/include/VPCEventHandler.hpp
+++ b/include/VPCEventHandler.hpp
@@ -216,13 +216,20 @@ protected:
       const int curr_num_changed_bounds,
       std::vector<std::vector<int> >& commonTermIndices,
       std::vector<std::vector<double> >& commonTermCoeff,
-      std::vector<double>& commonTermRHS);
+      std::vector<double>& commonTermRHS,
+      const double isPruned = false);
+
+  /// @brief Save disjunctive term using only stats vector, without solving for it
+  bool setupDisjunctiveTermFromStats();
 
   /// @brief Clear saved information and free memory
   void clearInformation();
 
   /// @brief Save node information before we reach endSearch_
   int saveInformation();
+
+  /// @brief Save node information using only #stats_ and #pruned_stats_ vectors
+  int saveInformationFromStats();
   //@}
 };
 /* VPCEventHandler definition */

--- a/include/VPCEventHandler.hpp
+++ b/include/VPCEventHandler.hpp
@@ -209,15 +209,23 @@ protected:
   /// @brief Copy our stuff
   void initialize(const VPCEventHandler* const rhs);
 
+  /// @brief Save disjunctive term using only stats vector, without solving for it
+  int setupDisjunctiveTermFromStats(const int orig_node_id,
+      const int branching_variable, const int branching_way,
+      const double branching_value, const int parent_num_changed_bounds,
+      const std::vector<std::vector<int> >& parentTermIndices,
+      const std::vector<std::vector<double> >& parentTermCoeff,
+      const std::vector<double>& parentTermRHS,
+      SolverInterface* const tmpSolver);
+
   /// @brief Solve for a disjunctive term
-  bool setupDisjunctiveTerm(const int node_id, const int branching_variable,
-      const int branching_way, const double branching_value,
-      const SolverInterface* const tmpSolverBase,
-      const int curr_num_changed_bounds,
-      std::vector<std::vector<int> >& commonTermIndices,
-      std::vector<std::vector<double> >& commonTermCoeff,
-      std::vector<double>& commonTermRHS,
-      const double isPruned = false);
+  bool setupDisjunctiveTerm(const int orig_node_id,
+      const int branching_variable, const int branching_way,
+      const double branching_value, const int parent_num_changed_bounds,
+      const std::vector<std::vector<int> >& parentTermIndices,
+      const std::vector<std::vector<double> >& parentTermCoeff,
+      const std::vector<double>& parentTermRHS,
+      const SolverInterface* const tmpSolverBase);
 
   /// @brief Clear saved information and free memory
   void clearInformation();
@@ -225,11 +233,6 @@ protected:
   /// @brief Save node information before we reach endSearch_
   int saveInformation();
 
-  /// @brief Save disjunctive term using only stats vector, without solving for it
-  bool setupDisjunctiveTermFromStats(const int orig_node_id,
-      const int branching_variable, const int branching_way, 
-      const double branching_value);
-  
   /// @brief Save node information using only #stats_ and #pruned_stats_ vectors
   int saveInformationFromStats();
   //@}

--- a/include/VPCEventHandler.hpp
+++ b/include/VPCEventHandler.hpp
@@ -219,15 +219,17 @@ protected:
       std::vector<double>& commonTermRHS,
       const double isPruned = false);
 
-  /// @brief Save disjunctive term using only stats vector, without solving for it
-  bool setupDisjunctiveTermFromStats();
-
   /// @brief Clear saved information and free memory
   void clearInformation();
 
   /// @brief Save node information before we reach endSearch_
   int saveInformation();
 
+  /// @brief Save disjunctive term using only stats vector, without solving for it
+  bool setupDisjunctiveTermFromStats(const int orig_node_id,
+      const int branching_variable, const int branching_way, 
+      const double branching_value);
+  
   /// @brief Save node information using only #stats_ and #pruned_stats_ vectors
   int saveInformationFromStats();
   //@}

--- a/include/common/Disjunction.hpp
+++ b/include/common/Disjunction.hpp
@@ -36,7 +36,7 @@ class DisjunctiveTerm {
 public:
   double obj = std::numeric_limits<double>::max(); ///< objective value
   std::vector<int> changed_var; ///< list of indices of variables with changed bounds
-  std::vector<int> changed_bound; ///< for each var in #changed_var, which bound was changaed: <= 0: lower bound, 1: upper bound
+  std::vector<int> changed_bound; ///< for each var in #changed_var, which bound was changed: <= 0: lower bound, 1: upper bound
   std::vector<double> changed_value; ///< new value of the variable
   bool is_feasible; ///< is this term LP-feasible?
 #ifdef USE_COIN

--- a/src/branch/VPCEventHandler.cpp
+++ b/src/branch/VPCEventHandler.cpp
@@ -1529,5 +1529,4 @@ int VPCEventHandler::saveInformationFromStats() {
   // }
 
   return status;
-} /* saveInformationFromStats */
-  
+} /* saveInformationFromStats */  

--- a/src/branch/VPCEventHandler.cpp
+++ b/src/branch/VPCEventHandler.cpp
@@ -468,7 +468,7 @@ VPCEventHandler::event(CbcEvent whichEvent) {
     // Check if we are done
     if (numLeafNodes_ >= maxNumLeafNodes_ || model_->getCurrentSeconds() >= maxTime_) {
       // Save information
-      const int status = saveInformation();
+      const int status = (this->owner->params.get(intParam::PARTIAL_BB_KEEP_PRUNED_NODES) == 0) ? saveInformation() : saveInformationFromStats();
       if (status == 0) {
 #ifdef TRACE
       printf(
@@ -1127,8 +1127,10 @@ bool VPCEventHandler::setupDisjunctiveTerm(const int node_id,
     
     DisjunctiveTerm term;
     if (SOLVER_IS_OPTIMAL) {
+#ifdef USE_COIN
       enableFactorization(tmpSolver, owner->params.get(doubleParam::EPS)); // this may change the solution slightly
       term.basis = dynamic_cast<CoinWarmStartBasis*>(tmpSolver->getWarmStart());
+#endif
       term.obj = tmpSolver->getObjValue();
       isFeasible = true;
     } else {
@@ -1419,28 +1421,25 @@ int VPCEventHandler::saveInformation() {
  * Setup disjunctive term using stats vector only
 */
 bool VPCEventHandler::setupDisjunctiveTermFromStats(
-  // const int orig_node_id,
-  // const int node_id,
-  // const std::vector<NodeStatistics> &curr_stats,
+  const int orig_node_id, ///< node id in #stats_ vector
+  const int branching_variable, ///< variable that was branch on to get to term
+  const int branching_way, ///< direction of branching (0 = down, 1 = up)
+  const double branching_value ///< value that branching variable's bound is set to
 ) {
-  // const int branching_index = curr_stats[node_id].branch_index;
-  // const int branching_variable = curr_stats[node_id].variable;
-  // int branching_way = stats_[node_id].way;
-  // double branching_value = (branching_way <= 0) ? stats_[node_id].ub : stats_[node_id].lb;
+  DisjunctiveTerm term;
+#ifdef USE_COIN
+  term.basis = NULL;
+#endif
+  term.obj = stats_[orig_node_id].obj; // will be inaccurate
+  term.changed_var = stats_[orig_node_id].changed_var;
+  term.changed_var.push_back(branching_variable);
+  term.changed_bound = stats_[orig_node_id].changed_bound;
+  term.changed_bound.push_back(branching_way == 1 ? 0 : 1);
+  term.changed_value = stats_[orig_node_id].changed_value;
+  term.changed_value.push_back(branching_value);
+  owner->terms.push_back(term);
 
-  // DisjunctiveTerm term;
-  // term.basis = NULL;
-  // term.obj = curr_stats[orig_node_id].obj; // might be inaccurate
-  // term.changed_var = curr_stats[orig_node_id].changed_var;
-  // term.changed_var.push_back(branching_variable);
-  // term.changed_bound = curr_stats[orig_node_id].changed_bound;
-  // term.changed_bound.push_back(branching_way == 1 ? 0 : 1);
-  // term.changed_value = curr_stats[orig_node_id].changed_value;
-  // term.changed_value.push_back(branching_value);
-  // owner->terms.push_back(term);
-  // isFeasible = true;
-
-  return false;
+  return true;
 } /* setupDisjunctiveTermFromStats */
 
 /**
@@ -1449,220 +1448,86 @@ bool VPCEventHandler::setupDisjunctiveTermFromStats(
  * @return status: 0 if everything is okay, otherwise 1 (e.g., if all but one of the terms is infeasible)
  */
 int VPCEventHandler::saveInformationFromStats() {
-//   int status = 0;
-//   const bool hitTimeLimit = model_->getCurrentSeconds() >= maxTime_;
-//   const bool hitHardNodeLimit = false;
-//   //const bool hitHardNodeLimit = model_->getNodeCount2() > maxNumLeafNodes_ * 10;
+  int status = 0;
+  // const bool hitTimeLimit = model_->getCurrentSeconds() >= maxTime_;
+  // const bool hitHardNodeLimit = false;
+  //const bool hitHardNodeLimit = model_->getNodeCount2() > maxNumLeafNodes_ * 10;
 
-//   clearInformation();
-//   this->owner->data.num_nodes_on_tree = this->getNumNodesOnTree();
-//   this->owner->data.num_partial_bb_nodes = model_->getNodeCount(); // save number of nodes looked at
-//   this->owner->data.num_pruned_nodes = this->getPrunedStatsVector().size();
-//   this->owner->data.num_fixed_vars = model_->strongInfo()[1]; // number fixed during b&b
+  clearInformation();
+  this->owner->data.num_nodes_on_tree = this->getNumNodesOnTree();
+  this->owner->data.num_partial_bb_nodes = model_->getNodeCount(); // save number of nodes looked at
+  this->owner->data.num_pruned_nodes = this->getPrunedStatsVector().size();
+  this->owner->data.num_fixed_vars = model_->strongInfo()[1]; // number fixed during b&b
 
-//   const std::vector<NodeStatistics>& stats = this->getStatsVector();
-//   const std::vector<NodeStatistics>& pruned_stats = this->getPrunedStatsVector();
-//   const int numLeafNodes = 2 * this->getNumNodesOnTree() + pruned_stats.size();
+  const std::vector<NodeStatistics>& stats = this->getStatsVector();
+  const std::vector<NodeStatistics>& pruned_stats = this->getPrunedStatsVector();
+  // const int numLeafNodes = 2 * this->getNumNodesOnTree() + pruned_stats.size();
 
-//   // Save variables with bounds that were changed at the root
-//   const int num_stats = stats.size();
-//   if (num_stats > 0) {
-//     this->owner->common_changed_bound = stats[0].changed_bound;
-//     this->owner->common_changed_value = stats[0].changed_value;
-//     this->owner->common_changed_var = stats[0].changed_var;
-//     this->owner->root.var = stats[0].variable;
-//     this->owner->root.val = stats[0].value;
-//   }
+  // Save variables with bounds that were changed at the root
+  const int num_stats = stats.size();
+  if (num_stats > 0) {
+    this->owner->common_changed_bound = stats[0].changed_bound;
+    this->owner->common_changed_value = stats[0].changed_value;
+    this->owner->common_changed_var = stats[0].changed_var;
+    this->owner->root.var = stats[0].variable;
+    this->owner->root.val = stats[0].value;
+  }
 
-//   // Add the leaf nodes that have not already been pruned
-//   // For each node on the tree, add a term for the two branches
-//   const int numActiveNodes = this->getNumNodesOnTree();
-//   for (int tmp_ind = 0; tmp_ind < numActiveNodes; tmp_ind++) {
-//     const int i = this->getNodeIndex(tmp_ind);
-//     const int node_id = stats[i].id;
-//     const int orig_node_id = stats[node_id].orig_id;
+  // Add the leaf nodes that have not already been pruned
+  // For each node on the tree, add a term for the two branches
+  // [Not needed here] Set up original basis including bounds changed at root
+  // CoinWarmStartBasis* original_basis = dynamic_cast<CoinWarmStartBasis*>(originalSolver_->getWarmStart());
+  const int numActiveNodes = this->getNumNodesOnTree();
+  for (int tmp_ind = 0; tmp_ind < numActiveNodes; tmp_ind++) {
+    // CoinWarmStartBasis* parent_basis = dynamic_cast<CoinWarmStartBasis*>(original_basis->clone());
+    CbcNode* node = model_->tree()->nodePointer(tmp_ind);
+    CbcNodeInfo* nodeInfo = node->nodeInfo();
+    // nodeInfo->buildRowBasis(*parent_basis);
+    finalNodeIndices_.push_back(stats[nodeInfo->nodeNumber()].id);
 
-//     // Collect changed bounds
-//     const int curr_num_changed_bounds =
-//         (orig_node_id == 0) ? 0 : stats[orig_node_id].changed_var.size();
-//     std::vector < std::vector<int> > commonTermIndices(curr_num_changed_bounds);
-//     std::vector < std::vector<double> > commonTermCoeff(curr_num_changed_bounds);
-//     std::vector<double> commonTermRHS(curr_num_changed_bounds);
+    const int i = this->getNodeIndex(tmp_ind);
+    const int node_id = stats[i].id;
+    const int orig_node_id = stats[node_id].orig_id;
+    const int branching_index = stats[node_id].branch_index;
+    const int branching_variable = stats[node_id].variable;
+    const int init_branching_way = (stats[orig_node_id].way == 1);
+    const double init_branching_value = (init_branching_way <= 0) ? stats[orig_node_id].ub : stats[orig_node_id].lb;
 
-//     const int branch = stats[i].branch_index;
-//     const int first_child_ind = (stats[i].way <= 0);
-//     const int parent_node_ind = stats[i].number;
-//     for (int b = branch; b < 2; b++) {
-//       const int tmp_child_ind = (b == 0) ? first_child_ind : !first_child_ind;
-//       const int child_ind = (tmp_child_ind == 0) ? 0 : 2; // reserve index 1 for strong branching "child"
-//     }
+    for (int b = branching_index; b < 2; b++) {
+      const int branching_way = (b == 0) ? init_branching_way : 1 - init_branching_way;
+      const double branching_value = 
+          (b == 0) 
+              ? init_branching_value 
+              : ((branching_way <= 0) ? init_branching_value - 1 : init_branching_value + 1);
+      
+      setupDisjunctiveTermFromStats(orig_node_id, branching_variable, branching_way, branching_value);
+    } // loop over branching ways
 
-//     // Change bounds in the solver
+    // if (parent_basis != NULL) {
+    //   delete parent_basis;
+    //   parent_basis = NULL;
+    // }
+  } // loop over active nodes
 
-//     // First the root node bounds
-//     const int init_num_changed_bounds = this->owner->common_changed_var.size();
-//     for (int i = 0; i < init_num_changed_bounds; i++) {
-//       const int col = this->owner->common_changed_var[i];
-//       const double val = this->owner->common_changed_value[i];
-//       if (this->owner->common_changed_bound[i] <= 0) {
-//         tmpSolverBase->setColLower(col, val);
-//       } else {
-//         tmpSolverBase->setColUpper(col, val);
-//       }
-//     }
+  // Add the pruned nodes
+  // For each pruned node, to get the changes to arrive at the node, 
+  // we retrieve the parent node and then branch using the parent's info
+  for (int tmp_ind = 0; tmp_ind < pruned_stats.size(); tmp_ind++) {
+    const int parent_id = pruned_stats[tmp_ind].parent_id;
+    const int node_id = parent_id;
+    const int orig_node_id = stats[node_id].orig_id;
+    const int branching_variable = stats[node_id].variable;
+    const int branching_way = (stats[node_id].way == 1);
+    const double branching_value = (branching_way <= 0) ? stats[node_id].ub : stats[node_id].lb;
 
-//     // Now the parent changed node bounds
-//     const int curr_num_changed_bounds =
-//         (orig_node_id == 0) ? 0 : stats_[orig_node_id].changed_var.size();
-//     std::vector < std::vector<int> > commonTermIndices(curr_num_changed_bounds);
-//     std::vector < std::vector<double> > commonTermCoeff(curr_num_changed_bounds);
-//     std::vector<double> commonTermRHS(curr_num_changed_bounds);
-//     for (int i = 0; i < curr_num_changed_bounds; i++) {
-//       const int col = stats_[orig_node_id].changed_var[i];
-//       const double coeff = (stats_[orig_node_id].changed_bound[i] <= 0) ? 1. : -1.;
-//       const double val = stats_[orig_node_id].changed_value[i];
-//       commonTermIndices[i].resize(1, col);
-//       commonTermCoeff[i].resize(1, coeff);
-//       commonTermRHS[i] = coeff * val;
-//       if (stats_[orig_node_id].changed_bound[i] <= 0) {
-//         tmpSolverBase->setColLower(col, val);
-//       } else {
-//         tmpSolverBase->setColUpper(col, val);
-//       }
-//     }
+    setupDisjunctiveTermFromStats(orig_node_id, branching_variable, branching_way, branching_value);
+  } // loop over pruned nodes
 
-// #ifdef TRACE
-//     double curr_nb_obj_val = tmpSolverBase->getObjValue() - originalSolver_->getObjValue();
-//     printf("DEBUG: Node: %d .......... Obj val: %.3f .......... NB obj val: %.3f\n", node_id,
-//         tmpSolverBase->getObjValue(), curr_nb_obj_val);
-//     printNodeStatistics(stats_[node_id], true);
-// #endif
-//     if (!isVal(tmpSolverBase->getObjValue(), stats_[node_id].obj,
-//         owner->params.get(doubleConst::DIFFEPS))) {
-// #ifdef TRACE
-//       std::string commonName;
-//       Disjunction::setCgsName(commonName, curr_num_changed_bounds, commonTermIndices,
-//           commonTermCoeff, commonTermRHS, false);
-//       printf("Bounds changed: %s.\n", commonName.c_str());
-// #endif
-//         }
+  // if (original_basis != NULL) {
+  //   delete original_basis;
+  //   original_basis = NULL;
+  // }
 
-
-//     // Now we check the branch or branches left for this node
-//     bool hasFeasibleChild = false;
-//     const int branching_index = stats_[node_id].branch_index;
-//     const int branching_variable = stats_[node_id].variable;
-//     int branching_way = stats_[node_id].way;
-//     double branching_value = (branching_way <= 0) ? stats_[node_id].ub : stats_[node_id].lb;
-//   } // loop over nodes still on tree
-
-
-//   std::vector<std::vector<int> > children(numNodes); // the children of this node (node indices)
-//   std::vector<std::vector<int> > locationOfChild(numNodes); // 0: children, 1: feas_children, 2: pruned_children, 3: unexplored_children, 4: feas children found during strong branching
-//   std::vector<int> variable(numNodes); // variable that was branched on to get to this node
-//   std::vector<double> obj(numNodes); // objective value at this node
-//   variable[0] = -1;
-//   obj[0] = this->getOriginalSolver()->getObjValue();
-
-//   // Assume there are at most 3 children
-//   // (middle "child" reserved for feas sol found during strong branching at that node)
-//   // There may be more / less in general
-//   for (int i = 0; i < numNodes; i++) {
-//     children[i].resize(3, -1);
-//     locationOfChild[i].resize(3, -1);
-//   }
-
-//   // First handle the nodes already explored
-//   for (int i = 0; i < (int) stats.size(); i++) {
-//     if (stats[i].orig_id != stats[i].id || stats[i].parent_id < 0) {
-//       continue; // skip if the node has already been handled
-//     }
-//     const int node_ind = stats[i].number;
-//     const int parent_id = stats[i].parent_id;
-//     const int parent_node_ind = stats[parent_id].number;
-//     const int child_ind = (stats[parent_id].way <= 0) ? 0 : 2;
-//     int loc = 0;
-//     if (stats[i].found_integer_solution && isVal(stats[i].obj, stats[i].integer_obj)) {
-//       loc = 1;
-//     }
-//     setChildForTikzTreeString(children, locationOfChild, loc,
-//         parent_node_ind, child_ind, node_ind);
-//     variable[node_ind] = stats[parent_id].variable;
-//     obj[node_ind] = stats[i].obj;
-//   }
-
-//   // Add the leaf nodes
-//   int numActiveNodes = this->getNumNodesOnTree();
-//   for (int tmp_ind = 0; tmp_ind < numActiveNodes; tmp_ind++) {
-//     const int i = this->getNodeIndex(tmp_ind);
-//     const int branch = stats[i].branch_index;
-//     const int first_child_ind = (stats[i].way <= 0);
-//     const int parent_node_ind = stats[i].number;
-//     for (int b = branch; b < 2; b++) {
-//       const int tmp_child_ind = (b == 0) ? first_child_ind : !first_child_ind;
-//       const int child_ind = (tmp_child_ind == 0) ? 0 : 2; // reserve index 1 for strong branching "child"
-//       setChildForTikzTreeString(children, locationOfChild, 3, parent_node_ind, child_ind, numNodesTotal);
-//       variable.push_back(stats[i].variable);
-//       obj.push_back(-1);
-//       numNodesTotal++;
-//     }
-//   }
-
-//   // Add the pruned nodes
-//   int numInfeasNodes = 0, numFeasNodes = 0;
-//   for (int i = 0; i < (int) pruned_stats.size(); i++) {
-//     const int node_ind = pruned_stats[i].number;
-//     assert(children[node_ind][0] == -1 && children[node_ind][1] == -1);
-//     const int parent_id = pruned_stats[i].parent_id;
-//     const int parent_node_ind = stats[parent_id].number;
-//     const int child_ind = (stats[parent_id].way <= 0) ? 0 : 2;
-//     variable[node_ind] = stats[parent_id].variable;
-//     obj[node_ind] = pruned_stats[i].obj;
-//     if (pruned_stats[i].found_integer_solution) {
-//       int loc = (pruned_stats[i].obj == pruned_stats[i].integer_obj);
-//       setChildForTikzTreeString(children, locationOfChild, loc, parent_node_ind, child_ind, node_ind);
-//       numFeasNodes++;
-//       if (loc == 0) {
-//         // An integer solution was found during strong branching
-//         // Add this as a child with loc set to 4
-//         children.resize(numNodes+numSBFeasNodes+1);
-//         locationOfChild.resize(numNodes+numSBFeasNodes+1);
-//         children[numNodes+numSBFeasNodes].resize(3,-1);
-//         locationOfChild[numNodes+numSBFeasNodes].resize(3,-1);
-//         loc = 4;
-//         setChildForTikzTreeString(children, locationOfChild, loc,
-//             node_ind, 1, numNodes+numSBFeasNodes); // place it in the middle
-//         variable.push_back(-1);
-//         obj.push_back(pruned_stats[i].integer_obj);
-//         numSBFeasNodes++;
-//       }
-//     } else { // although it says infeasible, it may have been pruned by bound...
-//       setChildForTikzTreeString(children, locationOfChild, 2, parent_node_ind, child_ind, node_ind);
-//       numInfeasNodes++;
-//     }
-//   }
-
-//   // In the case that there are no leaf nodes, move the dangling ones to pruned
-//   if (numActiveNodes == 0) {
-//     std::vector<bool> isLeafNode(numNodes, false);
-//     for (int i = numNodes - 1; i >= 0; i--) {
-//       int num_children = locationOfChild[i].size();
-//       int num_empty = 0;
-//       for (int j = 0; j < num_children; j++) {
-//         const int loc = locationOfChild[i][j];
-//         if (loc < 0) {
-//           num_empty++;
-//         } else if (loc == 0) {
-//           const int child_node_ind = children[i][j];
-//           if (isLeafNode[child_node_ind]) {
-//             locationOfChild[i][j] = 2;
-//           }
-//         }
-//       }
-//       if (num_children - num_empty == 0) {
-//         isLeafNode[i] = true;
-//       }
-//     }
-//   }
+  return status;
 } /* saveInformationFromStats */
   

--- a/src/branch/VPCEventHandler.cpp
+++ b/src/branch/VPCEventHandler.cpp
@@ -1095,54 +1095,96 @@ void VPCEventHandler::initialize(const VPCEventHandler* const source) {
   }
 } /* initialize */
 
-bool VPCEventHandler::setupDisjunctiveTerm(const int node_id,
-    const int branching_variable, const int branching_way,
-    const double branching_value, const SolverInterface* const tmpSolverBase,
-    const int curr_num_changed_bounds,
-    std::vector<std::vector<int> >& commonTermIndices,
-    std::vector<std::vector<double> >& commonTermCoeff,
-    std::vector<double>& commonTermRHS,
-    const double isPruned) {
-  bool isFeasible = false;
+/**
+ * @return Returns index of the term in the #owner->terms_ vector if the
+ *  disjunctive term was set up successfully.
+*/
+int VPCEventHandler::setupDisjunctiveTermFromStats(
+    const int orig_node_id, ///< node id in #stats_ vector
+    const int branching_variable, ///< variable that we branch on to get to term
+    const int branching_way, ///< direction of branching (0 = down, 1 = up)
+    const double branching_value, ///< value that branching variable's bound is set to
+    const int parent_num_changed_bounds,
+    const std::vector<std::vector<int> >& parentTermIndices,
+    const std::vector<std::vector<double> >& parentTermCoeff,
+    const std::vector<double>& parentTermRHS,
+    SolverInterface* const tmpSolver ///< solver to use to get objective value + basis
+) {
   const int ind[] = {branching_variable};
   const double coeff[] = {(branching_way <= 0) ? -1. : 1.};
   const double rhs = coeff[0] * branching_value;
-  std::vector<NodeStatistics>& curr_stats = isPruned ? pruned_stats_ : stats_;
-  const int orig_node_id = curr_stats[node_id].orig_id;
+  Disjunction::setCgsName(this->owner->name, 1, ind, coeff, rhs);
+  if (parent_num_changed_bounds > 0) {
+    Disjunction::setCgsName(this->owner->name, parent_num_changed_bounds,
+        parentTermIndices, parentTermCoeff, parentTermRHS, true);
+  }
 
-  SolverInterface* tmpSolver = dynamic_cast<SolverInterface*>(tmpSolverBase->clone());
-  if (branching_way <= 0)
-    tmpSolver->setColUpper(branching_variable, branching_value);
-  else
-    tmpSolver->setColLower(branching_variable, branching_value);
-  //tmpSolver->addRow(1, ind, coeff, rhs, tmpSolver->getInfinity());
-  tmpSolver->resolve();
-  const bool SOLVER_IS_OPTIMAL = checkSolverOptimality(tmpSolver, true);
-  if (SOLVER_IS_OPTIMAL || this->keepPrunedNodes_) {
-    this->owner->num_terms++;
-    Disjunction::setCgsName(this->owner->name, 1, ind, coeff, rhs);
-    if (curr_num_changed_bounds > 0)
-      Disjunction::setCgsName(this->owner->name, curr_num_changed_bounds,
-          commonTermIndices, commonTermCoeff, commonTermRHS, true);
-    
-    DisjunctiveTerm term;
-    if (SOLVER_IS_OPTIMAL) {
+  const bool USE_SOLVER_BASIS = tmpSolver != NULL && checkSolverOptimality(tmpSolver, true);
+
+  DisjunctiveTerm term;
+  if (USE_SOLVER_BASIS) {
 #ifdef USE_COIN
-      enableFactorization(tmpSolver, owner->params.get(doubleParam::EPS)); // this may change the solution slightly
-      term.basis = dynamic_cast<CoinWarmStartBasis*>(tmpSolver->getWarmStart());
+    enableFactorization(tmpSolver, owner->params.get(doubleParam::EPS)); // this may change the solution slightly
+    term.basis = dynamic_cast<CoinWarmStartBasis*>(tmpSolver->getWarmStart());
 #endif
-      term.obj = tmpSolver->getObjValue();
-      isFeasible = true;
-    } else {
-      term.obj = std::numeric_limits<double>::max();
+    term.obj = tmpSolver->getObjValue();
+    term.is_feasible = true;
+  } else {
+    term.obj = stats_[orig_node_id].obj; // will be inaccurate
+    term.basis = NULL;
+  }
+  term.changed_var = stats_[orig_node_id].changed_var;
+  term.changed_var.push_back(branching_variable);
+  term.changed_bound = stats_[orig_node_id].changed_bound;
+  term.changed_bound.push_back(branching_way == 1 ? 0 : 1);
+  term.changed_value = stats_[orig_node_id].changed_value;
+  term.changed_value.push_back(branching_value);
+  owner->terms.push_back(term);
+  this->owner->num_terms++;
+
+  return owner->terms.size() - 1;
+} /* setupDisjunctiveTermFromStats */
+
+bool VPCEventHandler::setupDisjunctiveTerm(
+    const int orig_node_id, ///< node id in #stats_ vector
+    const int branching_variable, ///< variable that we branch on to get to term
+    const int branching_way, ///< direction of branching (0 = down, 1 = up)
+    const double branching_value, ///< value that branching variable's bound is set to
+    const int parent_num_changed_bounds,
+    const std::vector<std::vector<int> >& parentTermIndices,
+    const std::vector<std::vector<double> >& parentTermCoeff,
+    const std::vector<double>& parentTermRHS,
+    const SolverInterface* const tmpSolverBase ///< solver of parent node (if available)
+) {
+  SolverInterface* tmpSolver = NULL;
+  
+  if (tmpSolverBase) {
+    tmpSolver = dynamic_cast<SolverInterface*>(tmpSolverBase->clone());
+    if (branching_way <= 0)
+      tmpSolver->setColUpper(branching_variable, branching_value);
+    else
+      tmpSolver->setColLower(branching_variable, branching_value);
+    //tmpSolver->addRow(1, ind, coeff, rhs, tmpSolver->getInfinity());
+    tmpSolver->resolve();
+  }
+  const bool isFeasible = tmpSolver != NULL && checkSolverOptimality(tmpSolver, true);
+
+  if (isFeasible || this->keepPrunedNodes_) {
+    const int term_ind = setupDisjunctiveTermFromStats(orig_node_id, branching_variable,
+        branching_way, branching_value, parent_num_changed_bounds,
+        parentTermIndices, parentTermCoeff, parentTermRHS,
+        isFeasible ? tmpSolver : NULL);
+
+    if (term_ind < 0) {
+      // Return error that term could not be set up
+      error_msg(errorstring,
+          "Term was not correctly set up for node %d with branching variable %d, branching way %d, and branching value %f.\n",
+          orig_node_id, branching_variable, branching_way, branching_value);
+      writeErrorToLog(errorstring, owner->params.logfile);
+      exit(1);
     }
-    term.changed_var = curr_stats[orig_node_id].changed_var;
-    term.changed_var.push_back(branching_variable);
-    term.changed_bound = curr_stats[orig_node_id].changed_bound;
-    term.changed_bound.push_back(branching_way == 1 ? 0 : 1);
-    term.changed_value = curr_stats[orig_node_id].changed_value;
-    term.changed_value.push_back(branching_value);
-    owner->terms.push_back(term);
+        
+    DisjunctiveTerm& term = owner->terms[term_ind];
 
     // Update the root node information
     // First, identify if this node is on the down or up part of the root split
@@ -1150,9 +1192,9 @@ bool VPCEventHandler::setupDisjunctiveTerm(const int node_id,
     // The other node with 0 as a parent is therefore the second child
     bool is_down = false, is_up = false;
     int curr_id = orig_node_id;
-    const int way = curr_stats[0].way;
+    const int way = stats_[0].way;
     while (!is_down && !is_up) {
-      if (curr_stats[curr_id].parent_id == -1) {
+      if (stats_[curr_id].parent_id == -1) {
         if (curr_id == 0) { // check if this is the first child of the root
           if (way <= 0)
             is_down = true;
@@ -1165,7 +1207,7 @@ bool VPCEventHandler::setupDisjunctiveTerm(const int node_id,
             is_down = true;
         }
       } else {
-        curr_id = curr_stats[curr_id].parent_id;
+        curr_id = stats_[curr_id].parent_id;
       }
     }
     // Now update the bound if possible
@@ -1266,19 +1308,19 @@ int VPCEventHandler::saveInformation() {
       }
     }
 
-    // Now the parent changed node bounds
-    const int curr_num_changed_bounds =
+    // Collect and apply the parent changed node bounds
+    const int parent_num_changed_bounds =
         (orig_node_id == 0) ? 0 : stats_[orig_node_id].changed_var.size();
-    std::vector < std::vector<int> > commonTermIndices(curr_num_changed_bounds);
-    std::vector < std::vector<double> > commonTermCoeff(curr_num_changed_bounds);
-    std::vector<double> commonTermRHS(curr_num_changed_bounds);
-    for (int i = 0; i < curr_num_changed_bounds; i++) {
+    std::vector < std::vector<int> > parentTermIndices(parent_num_changed_bounds);
+    std::vector < std::vector<double> > parentTermCoeff(parent_num_changed_bounds);
+    std::vector<double> parentTermRHS(parent_num_changed_bounds);
+    for (int i = 0; i < parent_num_changed_bounds; i++) {
       const int col = stats_[orig_node_id].changed_var[i];
       const double coeff = (stats_[orig_node_id].changed_bound[i] <= 0) ? 1. : -1.;
       const double val = stats_[orig_node_id].changed_value[i];
-      commonTermIndices[i].resize(1, col);
-      commonTermCoeff[i].resize(1, coeff);
-      commonTermRHS[i] = coeff * val;
+      parentTermIndices[i].resize(1, col);
+      parentTermCoeff[i].resize(1, coeff);
+      parentTermRHS[i] = coeff * val;
       if (stats_[orig_node_id].changed_bound[i] <= 0) {
         tmpSolverBase->setColLower(col, val);
       } else {
@@ -1328,8 +1370,8 @@ int VPCEventHandler::saveInformation() {
         owner->params.get(doubleConst::DIFFEPS))) {
 #ifdef TRACE
       std::string commonName;
-      Disjunction::setCgsName(commonName, curr_num_changed_bounds, commonTermIndices,
-          commonTermCoeff, commonTermRHS, false);
+      Disjunction::setCgsName(commonName, parent_num_changed_bounds, parentTermIndices,
+          parentTermCoeff, parentTermRHS, false);
       printf("Bounds changed: %s.\n", commonName.c_str());
 #endif
       // Allow it to be up to 3% off without causing an error
@@ -1361,9 +1403,9 @@ int VPCEventHandler::saveInformation() {
     printf("\n## Solving first child of parent %d/%d for term %d. ##\n",
         tmp_ind + 1, this->numNodesOnTree_, this->owner->num_terms);
 #endif
-    hasFeasibleChild = setupDisjunctiveTerm(node_id, branching_variable,
-        branching_way, branching_value, tmpSolverBase, curr_num_changed_bounds,
-        commonTermIndices, commonTermCoeff, commonTermRHS);
+    hasFeasibleChild = setupDisjunctiveTerm(orig_node_id,
+        branching_variable, branching_way, branching_value, parent_num_changed_bounds,
+        parentTermIndices, parentTermCoeff, parentTermRHS, tmpSolverBase);
 
     // Check if we exit early
     if (!hitTimeLimit && !hitHardNodeLimit 
@@ -1379,9 +1421,9 @@ int VPCEventHandler::saveInformation() {
       branching_way = (stats_[node_id].way <= 0) ? 1 : 0;
       branching_value =
           (branching_way <= 0) ? branching_value - 1 : branching_value + 1;
-      const bool childIsFeasible = setupDisjunctiveTerm(node_id, branching_variable, branching_way,
-              branching_value, tmpSolverBase, curr_num_changed_bounds,
-              commonTermIndices, commonTermCoeff, commonTermRHS);
+      const bool childIsFeasible = setupDisjunctiveTerm(orig_node_id,
+              branching_variable, branching_way, branching_value, parent_num_changed_bounds,
+              parentTermIndices, parentTermCoeff, parentTermRHS, tmpSolverBase);
       hasFeasibleChild = hasFeasibleChild || childIsFeasible;
     } // end second branch computation
 
@@ -1418,31 +1460,6 @@ int VPCEventHandler::saveInformation() {
 } /* saveInformation */
 
 /**
- * Setup disjunctive term using stats vector only
-*/
-bool VPCEventHandler::setupDisjunctiveTermFromStats(
-  const int orig_node_id, ///< node id in #stats_ vector
-  const int branching_variable, ///< variable that was branch on to get to term
-  const int branching_way, ///< direction of branching (0 = down, 1 = up)
-  const double branching_value ///< value that branching variable's bound is set to
-) {
-  DisjunctiveTerm term;
-#ifdef USE_COIN
-  term.basis = NULL;
-#endif
-  term.obj = stats_[orig_node_id].obj; // will be inaccurate
-  term.changed_var = stats_[orig_node_id].changed_var;
-  term.changed_var.push_back(branching_variable);
-  term.changed_bound = stats_[orig_node_id].changed_bound;
-  term.changed_bound.push_back(branching_way == 1 ? 0 : 1);
-  term.changed_value = stats_[orig_node_id].changed_value;
-  term.changed_value.push_back(branching_value);
-  owner->terms.push_back(term);
-
-  return true;
-} /* setupDisjunctiveTermFromStats */
-
-/**
  * Save all relevant information before it gets deleted by BB finishing
  *
  * @return status: 0 if everything is okay, otherwise 1 (e.g., if all but one of the terms is infeasible)
@@ -1475,14 +1492,14 @@ int VPCEventHandler::saveInformationFromStats() {
 
   // Add the leaf nodes that have not already been pruned
   // For each node on the tree, add a term for the two branches
-  // [Not needed here] Set up original basis including bounds changed at root
-  // CoinWarmStartBasis* original_basis = dynamic_cast<CoinWarmStartBasis*>(originalSolver_->getWarmStart());
+  // Set up original basis including bounds changed at root
+  CoinWarmStartBasis* original_basis = dynamic_cast<CoinWarmStartBasis*>(originalSolver_->getWarmStart());
   const int numActiveNodes = this->getNumNodesOnTree();
   for (int tmp_ind = 0; tmp_ind < numActiveNodes; tmp_ind++) {
-    // CoinWarmStartBasis* parent_basis = dynamic_cast<CoinWarmStartBasis*>(original_basis->clone());
+    CoinWarmStartBasis* parent_basis = dynamic_cast<CoinWarmStartBasis*>(original_basis->clone());
     CbcNode* node = model_->tree()->nodePointer(tmp_ind);
     CbcNodeInfo* nodeInfo = node->nodeInfo();
-    // nodeInfo->buildRowBasis(*parent_basis);
+    nodeInfo->buildRowBasis(*parent_basis);
     finalNodeIndices_.push_back(stats[nodeInfo->nodeNumber()].id);
 
     const int i = this->getNodeIndex(tmp_ind);
@@ -1493,6 +1510,52 @@ int VPCEventHandler::saveInformationFromStats() {
     const int init_branching_way = (stats[orig_node_id].way == 1);
     const double init_branching_value = (init_branching_way <= 0) ? stats[orig_node_id].ub : stats[orig_node_id].lb;
 
+    SolverInterface* tmpSolverBase =
+        dynamic_cast<SolverInterface*>(originalSolver_->clone());
+    setLPSolverParameters(tmpSolverBase, owner->params.get(VERBOSITY), owner->params.get(TIMELIMIT));
+//    tmpSolverBase->disableFactorization(); // seg fault
+
+    // Change bounds in the solver
+    // First the root node bounds
+    const int init_num_changed_bounds = this->owner->common_changed_var.size();
+    for (int i = 0; i < init_num_changed_bounds; i++) {
+      const int col = this->owner->common_changed_var[i];
+      const double val = this->owner->common_changed_value[i];
+      if (this->owner->common_changed_bound[i] <= 0) {
+        tmpSolverBase->setColLower(col, val);
+      } else {
+        tmpSolverBase->setColUpper(col, val);
+      }
+    }
+
+    // Collect and apply the parent changed node bounds
+    const int parent_num_changed_bounds =
+        (orig_node_id == 0) ? 0 : stats_[orig_node_id].changed_var.size();
+    std::vector < std::vector<int> > parentTermIndices(parent_num_changed_bounds);
+    std::vector < std::vector<double> > parentTermCoeff(parent_num_changed_bounds);
+    std::vector<double> parentTermRHS(parent_num_changed_bounds);
+    for (int i = 0; i < parent_num_changed_bounds; i++) {
+      const int col = stats_[orig_node_id].changed_var[i];
+      const double coeff = (stats_[orig_node_id].changed_bound[i] <= 0) ? 1. : -1.;
+      const double val = stats_[orig_node_id].changed_value[i];
+      parentTermIndices[i].resize(1, col);
+      parentTermCoeff[i].resize(1, coeff);
+      parentTermRHS[i] = coeff * val;
+      if (stats_[orig_node_id].changed_bound[i] <= 0) {
+        tmpSolverBase->setColLower(col, val);
+      } else {
+        tmpSolverBase->setColUpper(col, val);
+      }
+    }
+
+    // Set the parent node warm start
+    if (!(tmpSolverBase->setWarmStart(parent_basis))) {
+      error_msg(errorstring,
+          "Warm start information not accepted for parent node %d.\n", tmp_ind);
+      writeErrorToLog(errorstring, owner->params.logfile);
+      exit(1);
+    }
+
     for (int b = branching_index; b < 2; b++) {
       const int branching_way = (b == 0) ? init_branching_way : 1 - init_branching_way;
       const double branching_value = 
@@ -1500,18 +1563,21 @@ int VPCEventHandler::saveInformationFromStats() {
               ? init_branching_value 
               : ((branching_way <= 0) ? init_branching_value - 1 : init_branching_value + 1);
       
-      setupDisjunctiveTermFromStats(orig_node_id, branching_variable, branching_way, branching_value);
+      setupDisjunctiveTerm(orig_node_id,
+          branching_variable, branching_way, branching_value, parent_num_changed_bounds,
+          parentTermIndices, parentTermCoeff, parentTermRHS, tmpSolverBase);
     } // loop over branching ways
 
-    // if (parent_basis != NULL) {
-    //   delete parent_basis;
-    //   parent_basis = NULL;
-    // }
+    if (parent_basis != NULL) {
+      delete parent_basis;
+      parent_basis = NULL;
+    }
   } // loop over active nodes
 
   // Add the pruned nodes
   // For each pruned node, to get the changes to arrive at the node, 
   // we retrieve the parent node and then branch using the parent's info
+  // 2023-05-14 amk: we might not be able to compute basis since parent may be gone
   for (int tmp_ind = 0; tmp_ind < pruned_stats.size(); tmp_ind++) {
     const int parent_id = pruned_stats[tmp_ind].parent_id;
     const int node_id = parent_id;
@@ -1520,13 +1586,30 @@ int VPCEventHandler::saveInformationFromStats() {
     const int branching_way = (stats[node_id].way == 1);
     const double branching_value = (branching_way <= 0) ? stats[node_id].ub : stats[node_id].lb;
 
-    setupDisjunctiveTermFromStats(orig_node_id, branching_variable, branching_way, branching_value);
+    // Collect the parent changed node bounds
+    const int parent_num_changed_bounds =
+        (orig_node_id == 0) ? 0 : stats_[orig_node_id].changed_var.size();
+    std::vector < std::vector<int> > parentTermIndices(parent_num_changed_bounds);
+    std::vector < std::vector<double> > parentTermCoeff(parent_num_changed_bounds);
+    std::vector<double> parentTermRHS(parent_num_changed_bounds);
+    for (int i = 0; i < parent_num_changed_bounds; i++) {
+      const int col = stats_[orig_node_id].changed_var[i];
+      const double coeff = (stats_[orig_node_id].changed_bound[i] <= 0) ? 1. : -1.;
+      const double val = stats_[orig_node_id].changed_value[i];
+      parentTermIndices[i].resize(1, col);
+      parentTermCoeff[i].resize(1, coeff);
+      parentTermRHS[i] = coeff * val;
+    }
+
+    setupDisjunctiveTerm(orig_node_id,
+        branching_variable, branching_way, branching_value, parent_num_changed_bounds,
+        parentTermIndices, parentTermCoeff, parentTermRHS, NULL);
   } // loop over pruned nodes
 
-  // if (original_basis != NULL) {
-  //   delete original_basis;
-  //   original_basis = NULL;
-  // }
+  if (original_basis != NULL) {
+    delete original_basis;
+    original_basis = NULL;
+  }
 
   return status;
 } /* saveInformationFromStats */  

--- a/src/disjunction/Disjunction.cpp
+++ b/src/disjunction/Disjunction.cpp
@@ -51,7 +51,13 @@ void DisjunctiveTerm::initialize(const DisjunctiveTerm* const source) {
     changed_value = source->changed_value;
     is_feasible = source->is_feasible;
 #ifdef USE_COIN
-    basis = source->basis->clone();
+    if (basis) {
+      delete basis;
+      basis = NULL;
+    }
+    if (source->basis) {
+      basis = source->basis->clone();
+    }
     ineqs = source->ineqs;
 #endif
   } else {

--- a/src/disjunction/PartialBBDisjunction.cpp
+++ b/src/disjunction/PartialBBDisjunction.cpp
@@ -266,7 +266,8 @@ DisjExitReason PartialBBDisjunction::prepareDisjunction(const OsiSolverInterface
 
   // Make sure that the right number of terms has been saved
   if ((num_terms != eventHandler->getNumLeafNodes())
-      || (num_terms != static_cast<int>(terms.size() + eventHandler->isIntegerSolutionFound()))) {
+      || (params.get(intParam::PARTIAL_BB_KEEP_PRUNED_NODES) == 0 
+            && (num_terms != static_cast<int>(terms.size() + eventHandler->isIntegerSolutionFound())))) {
     error_msg(errstr,
         "Number of terms does not match: num terms = %d, num leaf nodes = %d, num bases = %d, found_integer_sol = %d\n",
         num_terms, eventHandler->getNumLeafNodes(), static_cast<int>(terms.size()),


### PR DESCRIPTION
Initial working (?) version of code to save *all* leaf nodes, including those that are pruned. No basis information is stored for pruned nodes. Accessible by setting option --partial_bb_keep_pruned=1. Good to test with --temp=32768 option to see b&b tree.